### PR TITLE
Make connections spawn the callbacks

### DIFF
--- a/src/Connection.lua
+++ b/src/Connection.lua
@@ -1,7 +1,7 @@
 local Connection = {}
 Connection.__index = Connection
 
-function Connection.new(callback,disconnectFunct)
+function Connection.new(callback,disconnectFunct)	--This code looks atrocious and probably isn't optimal.
 	local newConnection = {}
 	newConnection.callback = callback
 	newConnection.disconnectFunction = disconnectFunct

--- a/src/init.lua
+++ b/src/init.lua
@@ -15,12 +15,12 @@ function Event:Connect(callback)
 	table.insert(self.connections,newConnection)
 	return newConnection
 end
-function Event:RemoveEvent(event)
+function Event:RemoveEvent(event)	--Alternative methods need testing for better performance
 	table.remove(self.connections,table.find(self.connections,event))
 end
 function Event:Fire()
 	for k,v in pairs(self.connections) do
-		v.callback()
+		task.spawn(v.callback)
 	end
 end
 


### PR DESCRIPTION
Previously, the module would call the callbacks one after another, now it will spawn them all at once using task.spawn